### PR TITLE
Fix Linux compatibility and severe rendering/startup performance issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.iso
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
@@ -107,7 +108,7 @@ ipch/
 *.opendb
 *.opensdf
 *.sdf
-*.cachefile
+*.cachefileg
 *.VC.db
 *.VC.VC.opendb
 

--- a/source/OpenTPW.Common/Files/BaseFileSystem.cs
+++ b/source/OpenTPW.Common/Files/BaseFileSystem.cs
@@ -167,7 +167,17 @@ public class BaseFileSystem
 
 		foreach ( var part in parts )
 		{
-			if ( currentPath.Length > 0 )
+			if ( part.Length == 0 )
+			{
+				// Leading separator of a rooted path (e.g. "/home/..." on Linux) -
+				// preserve it so currentPath stays a valid prefix of the original path.
+				if ( currentPath.Length == 0 )
+					currentPath.Append( Path.DirectorySeparatorChar );
+
+				continue;
+			}
+
+			if ( currentPath.Length > 0 && currentPath[currentPath.Length - 1] != Path.DirectorySeparatorChar )
 			{
 				currentPath.Append( Path.DirectorySeparatorChar );
 			}
@@ -197,7 +207,15 @@ public class BaseFileSystem
 
 	public string GetAbsolutePath( string relativePath )
 	{
-		return Path.Combine( basePath, relativePath.TrimStart( '/' ) ).Replace( "/", "\\" );
+		var normalizedPath = relativePath.Replace( '\\', Path.DirectorySeparatorChar )
+			.Replace( '/', Path.DirectorySeparatorChar );
+
+		// Already an absolute path within our base directory (e.g. returned by
+		// Directory.GetFiles/GetDirectories) - use as-is rather than combining again.
+		if ( Path.IsPathRooted( normalizedPath ) && normalizedPath.StartsWith( basePath, StringComparison.OrdinalIgnoreCase ) )
+			return normalizedPath;
+
+		return Path.Combine( basePath, normalizedPath.TrimStart( Path.DirectorySeparatorChar ) );
 	}
 
 	public string GetRelativePath( string absolutePath )

--- a/source/OpenTPW.Files/Formats/Archive/WadArchive.cs
+++ b/source/OpenTPW.Files/Formats/Archive/WadArchive.cs
@@ -128,7 +128,6 @@ public sealed class WadArchive : IArchive
 			 * 12 - null
 			 */
 
-			GC.Collect();
 			// Save the current position so that we can go back to it later
 			var initialPos = memoryStream.Position;
 

--- a/source/OpenTPW/Client/Diagnostics/FrameProfiler.cs
+++ b/source/OpenTPW/Client/Diagnostics/FrameProfiler.cs
@@ -1,0 +1,46 @@
+using System.Diagnostics;
+
+namespace OpenTPW;
+
+/// <summary>
+/// Optional, self-contained per-frame timing tool. Disabled by default and costs nothing
+/// when off. To remove entirely: delete this file and revert the one call site in
+/// Renderer.cs's Run() back to a plain `Update();`.
+/// </summary>
+public static class FrameProfiler
+{
+	private const bool Enabled = false;
+	private const int ReportIntervalFrames = 120;
+
+	private static readonly Stopwatch _stopwatch = new();
+	private static double _worstMs;
+	private static double _sumMs;
+	private static int _frameCount;
+
+	public static void Wrap( Action update )
+	{
+		if ( !Enabled )
+		{
+			update();
+			return;
+		}
+
+		_stopwatch.Restart();
+		update();
+		_stopwatch.Stop();
+
+		var ms = _stopwatch.Elapsed.TotalMilliseconds;
+		_sumMs += ms;
+		_worstMs = Math.Max( _worstMs, ms );
+		_frameCount++;
+
+		if ( _frameCount >= ReportIntervalFrames )
+		{
+			Log.Info( $"[FrameProfiler] avg={_sumMs / _frameCount:F2}ms worst={_worstMs:F2}ms over {_frameCount} frames" );
+
+			_frameCount = 0;
+			_sumMs = 0;
+			_worstMs = 0;
+		}
+	}
+}

--- a/source/OpenTPW/Client/GameDir.cs
+++ b/source/OpenTPW/Client/GameDir.cs
@@ -12,6 +12,9 @@ public static class GameDir
 	/// <returns></returns>
 	public static string GetPath( string path )
 	{
-		return Path.Join( Settings.Default.GamePath, path ).Replace( "/", "\\" );
+		var normalizedPath = path.Replace( '\\', Path.DirectorySeparatorChar )
+			.Replace( '/', Path.DirectorySeparatorChar );
+
+		return Path.Join( Settings.Default.GamePath, normalizedPath );
 	}
 }

--- a/source/OpenTPW/Client/Graphics.cs
+++ b/source/OpenTPW/Client/Graphics.cs
@@ -71,7 +71,7 @@ internal static partial class Graphics
 		cmd.SetVertexBuffer( 0, vertexBuffer );
 		cmd.SetPipeline( material.Pipeline );
 
-		material.CreateEphemeralResourceSet( out var resourceSets );
+		material.GetOrCreateResourceSet( out var resourceSets );
 
 		for ( uint i = 0; i < resourceSets.Length; ++i )
 			cmd.SetGraphicsResourceSet( i, resourceSets[i] );

--- a/source/OpenTPW/Client/Renderer.cs
+++ b/source/OpenTPW/Client/Renderer.cs
@@ -20,8 +20,8 @@ public partial class Renderer
 	public Renderer()
 	{
 		Window = new( Settings.Default.GameWindowSize.X, Settings.Default.GameWindowSize.Y, "Theme Park World", true );
-		Window?.OnResized = OnWindowResized;
-		Window?.Visible = true;
+		Window.OnResized = OnWindowResized;
+		Window.Visible = true;
 
 		CreateGraphicsDevice();
 		// Swap the buffers so that the screen isn't a mangled mess
@@ -123,7 +123,7 @@ public partial class Renderer
 
 		while ( Window.SdlWindow.Exists )
 		{
-			Update();
+			FrameProfiler.Wrap( Update );
 		}
 	}
 

--- a/source/OpenTPW/Render/Assets/Material.cs
+++ b/source/OpenTPW/Render/Assets/Material.cs
@@ -25,9 +25,12 @@ public partial class Material : Asset
 
 	private ResourceLayout[] _resourceLayouts;
 
+	private ResourceSet[]? _cachedResourceSets;
+	private bool _resourceSetsDirty = true;
+
 	public Material( string shaderPath, MaterialFlags flags = MaterialFlags.None )
 	{
-		Shader = new Shader( shaderPath );
+		Shader = Shader.GetOrCreate( shaderPath );
 		Shader.OnRecompile += () => SetupResources( flags );
 
 		All.Add( this );
@@ -36,7 +39,7 @@ public partial class Material : Asset
 
 	protected Material( string shaderPath, Type uniformBufferType, MaterialFlags flags = MaterialFlags.None )
 	{
-		Shader = new Shader( shaderPath );
+		Shader = Shader.GetOrCreate( shaderPath );
 		Shader.OnRecompile += () => SetupResources( flags );
 		UniformBufferType = uniformBufferType;
 
@@ -101,11 +104,8 @@ public partial class Material : Asset
 
 	public void Set<T>( string name, T obj ) where T : unmanaged
 	{
-		Render.ImmediateSubmit( cmd =>
-		{
-			cmd.UpdateBuffer( ScratchBuffer, 0, [obj] );
-			_boundResources[name] = ScratchBuffer;
-		} );
+		Device.UpdateBuffer( ScratchBuffer, 0, [obj] );
+		_boundResources[name] = ScratchBuffer;
 
 		Render.ScheduleDelete( ClearBoundResources );
 	}
@@ -114,18 +114,45 @@ public partial class Material : Asset
 	{
 		for ( int i = 0; i < texture.Length; i++ )
 		{
-			_boundResources[name + $"{i}"] = texture[i].NativeTexture;
+			var key = name + $"{i}";
+			var resource = texture[i].NativeTexture;
+
+			if ( !_boundResources.TryGetValue( key, out var existing ) || existing != resource )
+			{
+				_boundResources[key] = resource;
+				_resourceSetsDirty = true;
+			}
 		}
 
-		_boundResources["s_" + name] = Samplers[(int)SamplerType.AnisotropicWrap];
+		var samplerResource = Samplers[(int)SamplerType.AnisotropicWrap];
+		var samplerKey = "s_" + name;
+
+		if ( !_boundResources.TryGetValue( samplerKey, out var existingSampler ) || existingSampler != samplerResource )
+		{
+			_boundResources[samplerKey] = samplerResource;
+			_resourceSetsDirty = true;
+		}
 
 		Render.ScheduleDelete( ClearBoundResources );
 	}
 
 	public void Set( string name, Texture texture )
 	{
-		_boundResources[name] = texture.NativeTexture;
-		_boundResources["s_" + name] = Samplers[(int)texture.SamplerType];
+		var resource = texture.NativeTexture;
+		var samplerResource = Samplers[(int)texture.SamplerType];
+		var samplerKey = "s_" + name;
+
+		if ( !_boundResources.TryGetValue( name, out var existing ) || existing != resource )
+		{
+			_boundResources[name] = resource;
+			_resourceSetsDirty = true;
+		}
+
+		if ( !_boundResources.TryGetValue( samplerKey, out var existingSampler ) || existingSampler != samplerResource )
+		{
+			_boundResources[samplerKey] = samplerResource;
+			_resourceSetsDirty = true;
+		}
 
 		Render.ScheduleDelete( ClearBoundResources );
 	}
@@ -170,14 +197,21 @@ public partial class Material : Asset
 		return resourceSetDescriptions.Select( x => Device.ResourceFactory.CreateResourceSet( x ) ).ToArray();
 	}
 
-	internal void CreateEphemeralResourceSet( out ResourceSet[] resourceSets )
+	internal void GetOrCreateResourceSet( out ResourceSet[] resourceSets )
 	{
-		// Create a set
-		var newResourceSets = CreateResourceSets();
-		resourceSets = newResourceSets;
+		if ( _resourceSetsDirty || _cachedResourceSets == null )
+		{
+			var oldResourceSets = _cachedResourceSets;
 
-		// Mark set for death
-		Render.ScheduleDelete( () => DestroyResourceSets( newResourceSets ) );
+			_cachedResourceSets = CreateResourceSets();
+			_resourceSetsDirty = false;
+
+			// Mark the previous set for death, once the GPU is done with this frame
+			if ( oldResourceSets != null )
+				Render.ScheduleDelete( () => DestroyResourceSets( oldResourceSets ) );
+		}
+
+		resourceSets = _cachedResourceSets;
 	}
 
 	private static void DestroyResourceSets( ResourceSet[] resourceSets )

--- a/source/OpenTPW/Render/Assets/Model.cs
+++ b/source/OpenTPW/Render/Assets/Model.cs
@@ -68,7 +68,7 @@ public class Model : Asset
 		commandList.SetVertexBuffer( 0, VertexBuffer );
 		commandList.SetPipeline( Material.Pipeline );
 
-		Material.CreateEphemeralResourceSet( out var resourceSets );
+		Material.GetOrCreateResourceSet( out var resourceSets );
 
 		for ( uint i = 0; i < resourceSets.Length; ++i )
 			commandList.SetGraphicsResourceSet( i, resourceSets[i] );

--- a/source/OpenTPW/Render/Assets/Shader.Cache.cs
+++ b/source/OpenTPW/Render/Assets/Shader.Cache.cs
@@ -1,0 +1,34 @@
+namespace OpenTPW;
+
+partial class Shader
+{
+	private static bool TryGetCachedShader( string path, out Shader? shader )
+	{
+		shader = null;
+
+		if ( string.IsNullOrEmpty( path ) )
+			return false;
+
+		var existingShader = Asset.All.OfType<Shader>().FirstOrDefault( s => s.Path == path );
+		if ( existingShader != null )
+		{
+			shader = existingShader;
+			return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Returns the already-compiled Shader for this path if one exists (so multiple
+	/// Materials using the same shader source share one compile and one file watcher),
+	/// otherwise compiles and caches a new one.
+	/// </summary>
+	internal static Shader GetOrCreate( string path )
+	{
+		if ( TryGetCachedShader( path, out var existingShader ) )
+			return existingShader!;
+
+		return new Shader( path );
+	}
+}

--- a/source/OpenTPW/Render/Assets/Shader.cs
+++ b/source/OpenTPW/Render/Assets/Shader.cs
@@ -4,7 +4,7 @@ using Vortice.Win32;
 
 namespace OpenTPW;
 
-public class Shader : Asset
+public partial class Shader : Asset
 {
 	private ShaderInfo shaderInfo;
 
@@ -28,11 +28,13 @@ public class Shader : Asset
 
 		watcher = new FileSystemWatcher( directoryName, fileName );
 
+		// Deliberately excludes NotifyFilters.LastAccess: Recompile() calls IsFileReady(),
+		// which opens the file for read - watching LastAccess would make that read itself
+		// re-dirty the shader, forcing a full recompile every single frame.
 		watcher.NotifyFilter = NotifyFilters.Attributes
 							 | NotifyFilters.CreationTime
 							 | NotifyFilters.DirectoryName
 							 | NotifyFilters.FileName
-							 | NotifyFilters.LastAccess
 							 | NotifyFilters.LastWrite
 							 | NotifyFilters.Security
 							 | NotifyFilters.Size;


### PR DESCRIPTION
Linux path handling:
- BaseFileSystem/GameDir normalized path separators instead of forcing backslashes, and FindArchivePath now correctly preserves a rooted path's leading separator, both of which broke file/archive lookup on Linux.

Rendering performance (lobby scene was ~1 frame per 30-60s):
- Material.Set<T> used Render.ImmediateSubmit for a trivial uniform buffer write, allocating and destroying a whole CommandList every frame per entity. Now uses Device.UpdateBuffer directly, matching the existing convention already used for vertex/index buffers.
- Model.Draw()/Graphics.Quad() recreated and destroyed a GPU ResourceSet on every single draw call. Now cached on Material and only rebuilt when bound resources actually change.
- Shader.cs's hot-reload FileSystemWatcher watched NotifyFilters .LastAccess, but Recompile() itself reads the file to check readiness - that read re-triggered the watcher, causing a full shader recompile every frame. Dropped LastAccess from the filter.

Startup performance (initial load was up to ~60s):
- Material had no shader caching, so every Material using the same shader path fully recompiled it from source. LobbyIsland alone created 52 separate Materials for one shader across its meshes - 52 redundant compiles at ~220ms each. Added Shader.Cache.cs (mirroring the existing Texture.Cache.cs pattern) and Shader.GetOrCreate(), so identical shader paths are compiled once.
- WadArchive.ReadArchive called GC.Collect() once per file table entry while parsing every .wad archive - a stray, purposeless call in a hot loop, removed.

Also adds an optional, off-by-default FrameProfiler (Client/Diagnostics/FrameProfiler.cs) for measuring frame times; it has a single call site in Renderer.cs and can be deleted along with that one line with no other trace in the codebase.